### PR TITLE
Fix encoding issue when importing

### DIFF
--- a/app/lib/sec_client.rb
+++ b/app/lib/sec_client.rb
@@ -24,7 +24,7 @@ class SecClient
     col_names = nil
 
     IO.foreach(filename) do |raw_line|
-      line = raw_line.strip.split("|")
+      line = raw_line.encode("UTF-8", invalid: :replace, replace: "").strip.split("|")
       next unless line.size == EXPECTED_COL_NAMES.size
 
       if col_names.blank?


### PR DESCRIPTION
When running `bundle exec rake filings:import_all`, the process would fail at 2017 Q3 because some characters were not encoded in UTF-8. There may be a better way to fix this, but my fix was to replace the characters as you can see in the change made to `app/lib/sec_client.rb` in this PR. Ideally, we could update the encoding somehow so that we aren't losing any characters, but this suffices to at least get the import to complete.