### PR TITLE
Require user agent per SEC guidelines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 
 /public/assets
 .byebug_history
+.env
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'webpacker', '~> 5.0'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'dotenv-rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,10 @@ GEM
     delayed_job_active_record (4.1.6)
       activerecord (>= 3.0, < 6.2)
       delayed_job (>= 3.0, < 5)
+    dotenv (2.8.1)
+    dotenv-rails (2.8.1)
+      dotenv (= 2.8.1)
+      railties (>= 3.2)
     down (5.2.3)
       addressable (~> 2.8)
     erubi (1.10.0)
@@ -140,7 +144,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.12.3-x86_64-linux)
       racc (~> 1.4)
-    pg (1.2.3)
+    pg (1.5.3)
     public_suffix (4.0.6)
     puma (5.4.0)
       nio4r (~> 2.0)
@@ -236,6 +240,7 @@ DEPENDENCIES
   capybara (>= 3.26)
   clockwork (~> 2.0)
   delayed_job_active_record (~> 4.1)
+  dotenv-rails
   down (~> 5.2)
   foreman (~> 0.87)
   get_process_mem

--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ bundle exec rake db:setup
 yarn
 ```
 
+### Declare user agent with the SEC
+
+Per the [SEC Webmaster FAQ](https://www.sec.gov/os/webmaster-faq#code-support), you need to declare your user agent:
+
+`User-Agent: Sample Company Name AdminContact@<sample company domain>.com`
+
+The app looks for an environment variable called `SEC_USER_AGENT`, you can set it in development by creating a `.env` file in the project root and adding `SEC_USER_AGENT="Sample Company Name AdminContact@<sample company domain>.com"`, substituting your own name/email
+
 ### Database schema
 
 There are three main tables:

--- a/app/lib/minimal_db_seeder.rb
+++ b/app/lib/minimal_db_seeder.rb
@@ -36,7 +36,13 @@ class MinimalDbSeeder
     Delayed::Worker.new.work_off(1000)
 
     puts "#{Time.zone.now}: deleting unprocessed filings"
-    ThirteenF.unprocessed.where("created_at > ?", start_time).delete_all
+
+    ThirteenF.
+      unprocessed.
+      where("created_at > ?", start_time).
+      where.not(cik: ciks).
+      delete_all
+
     ThirteenFFiler.refresh!
 
     puts "#{Time.zone.now}: done, minimal db now available"

--- a/app/lib/sec_client.rb
+++ b/app/lib/sec_client.rb
@@ -192,13 +192,13 @@ class SecClient
     end
   end
 
-  private
-
   def get(url)
-    response = HTTParty.get(url)
+    response = HTTParty.get(url, headers: request_headers)
     raise RateLimited if response.code == 429
     response
   end
+
+  private
 
   def padded_cik(str_or_int)
     str_or_int.to_s.strip.rjust(10, "0")
@@ -213,5 +213,18 @@ class SecClient
     index_url.
       gsub(/\-index.html?\z/i, "").
       gsub("-", "")
+  end
+
+  # https://www.sec.gov/os/webmaster-faq#code-support
+  def user_agent
+    if ENV["SEC_USER_AGENT"].blank?
+      raise "No SEC_USER_AGENT environment variable set"
+    end
+
+    ENV["SEC_USER_AGENT"]
+  end
+
+  def request_headers
+    {"User-Agent" => user_agent}
   end
 end

--- a/app/models/thirteen_f.rb
+++ b/app/models/thirteen_f.rb
@@ -143,9 +143,9 @@ class ThirteenF < ApplicationRecord
 
   def cache_xml_data
     self.primary_doc_url = client.primary_doc_url(xml_urls)
-    self.primary_doc_xml = HTTParty.get(primary_doc_url).body if primary_doc_url
+    self.primary_doc_xml = client.get(primary_doc_url).body if primary_doc_url
     self.info_table_url = client.info_table_url(xml_urls)
-    self.info_table_xml = HTTParty.get(info_table_url).body if info_table_url
+    self.info_table_xml = client.get(info_table_url).body if info_table_url
     self.xml_data_fetched_at = Time.zone.now
 
     save!


### PR DESCRIPTION
Requires user to create a `.env` file and add the `SEC_USER_AGENT` environment variable. From the SEC's website:

<img width="608" alt="image" src="https://github.com/toddwschneider/sec-13f-filings/assets/70271/00e05463-1365-4de1-a2be-083ce370f0a0">

https://www.sec.gov/os/webmaster-faq#code-support